### PR TITLE
fix: 🐛 fix file names in rollup config

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -71,7 +71,7 @@ if (!argv.format || argv.format === 'es') {
     ...baseConfig,
     external,
     output: {
-      file: 'dist/disco-components.esm.js',
+      file: 'dist/disco-vue-components.esm.js',
       format: 'esm',
       exports: 'named'
     },
@@ -105,7 +105,7 @@ if (!argv.format || argv.format === 'cjs') {
     external,
     output: {
       compact: true,
-      file: 'dist/disco-components.ssr.js',
+      file: 'dist/disco-vue-components.ssr.js',
       format: 'cjs',
       name: 'DiscoComponents',
       exports: 'named',
@@ -134,7 +134,7 @@ if (!argv.format || argv.format === 'iife') {
     external,
     output: {
       compact: true,
-      file: 'dist/disco-components.min.js',
+      file: 'dist/disco-vue-components.min.js',
       format: 'iife',
       name: 'DiscoComponents',
       exports: 'named',


### PR DESCRIPTION
The file names in `package.json` did not match the file names in
`rollup.config.js`. They need to match to import the correct files.