### PR TITLE
Change rollup vue plugin

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -1,7 +1,7 @@
 // rollup.config.js
 import fs from 'fs';
 import path from 'path';
-import vue from 'rollup-plugin-vue';
+import vue from 'rollup-plugin-vue2';
 import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "rollup": "^2.7.3",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-terser": "^7.0.2",
-    "rollup-plugin-vue": "^6.0.0",
+    "rollup-plugin-vue2": "^0.8.1",
     "sass": "^1.26.10",
     "sass-loader": "^10.1.1",
     "semantic-release": "^17.1.1",


### PR DESCRIPTION
It seems like we need to explicitly use rollup-plugin-vue2 instead of rollup-plugin-vue.